### PR TITLE
Update types.yml

### DIFF
--- a/_data/types.yml
+++ b/_data/types.yml
@@ -9,4 +9,6 @@
   sub: RO
 - name: Speech/SigProc
   sub: SP
+- name: Reasoning & Inference
+  sub: RI
 


### PR DESCRIPTION
Adding new category: Reasoning & Inference, to accommodate conferences like ICAPS (Conference on Automated Planning & Scheduling), AAMAS etc. 